### PR TITLE
Fix nucleic acid enrichers

### DIFF
--- a/complex-go-export/pom.xml
+++ b/complex-go-export/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>complex-go-export</artifactId>

--- a/complex-pdb-export/pom.xml
+++ b/complex-pdb-export/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>complex-pdb-export</artifactId>

--- a/complex-tab-export/pom.xml
+++ b/complex-tab-export/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
 

--- a/complex-uniprot-dr-export/pom.xml
+++ b/complex-uniprot-dr-export/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>complex-uniprot-dr-export</artifactId>

--- a/cttv-exporter/pom.xml
+++ b/cttv-exporter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/imex-id-update/pom.xml
+++ b/imex-id-update/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.ac.ebi.intact.dataexchange.imex</groupId>

--- a/intact-cvutils/pom.xml
+++ b/intact-cvutils/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/intact-db-importer/pom.xml
+++ b/intact-db-importer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-db-importer</artifactId>

--- a/intact-db-importer/src/main/resources/META-INF/intact-importer-spring.xml
+++ b/intact-db-importer/src/main/resources/META-INF/intact-importer-spring.xml
@@ -266,13 +266,13 @@
             <batch:chunk reader="interactionEvidenceReader"
                          processor="interactionEvidenceProcessor"
                          writer="interactionEvidenceImporter"
-                         commit-interval="50"
-                         retry-limit="10">
+                         commit-interval="50">
+<!--                         retry-limit="10">-->
 
-                <batch:retryable-exception-classes>
-                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>
-                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>
-                </batch:retryable-exception-classes>
+<!--                <batch:retryable-exception-classes>-->
+<!--                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>-->
+<!--                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>-->
+<!--                </batch:retryable-exception-classes>-->
 
                 <batch:streams>
                     <batch:stream ref="interactionEvidenceReader"/>
@@ -292,13 +292,13 @@
             <batch:chunk reader="modelledInteractionReader"
                          processor="modelledInteractionProcessor"
                          writer="modelledInteractionImporter"
-                         commit-interval="50"
-                         retry-limit="10">
+                         commit-interval="50">
+<!--                         retry-limit="10">-->
 
-                <batch:retryable-exception-classes>
-                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>
-                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>
-                </batch:retryable-exception-classes>
+<!--                <batch:retryable-exception-classes>-->
+<!--                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>-->
+<!--                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>-->
+<!--                </batch:retryable-exception-classes>-->
 
                 <batch:streams>
                     <batch:stream ref="modelledInteractionReader"/>
@@ -318,13 +318,13 @@
             <batch:chunk reader="complexReader"
                          processor="intactComplexEnricherCompositeProcessor"
                          writer="complexImporter"
-                         commit-interval="50"
-                         retry-limit="10">
+                         commit-interval="50">
+<!--                         retry-limit="10">-->
 
-                <batch:retryable-exception-classes>
-                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>
-                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>
-                </batch:retryable-exception-classes>
+<!--                <batch:retryable-exception-classes>-->
+<!--                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>-->
+<!--                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>-->
+<!--                </batch:retryable-exception-classes>-->
 
                 <batch:streams>
                     <batch:stream ref="complexReader"/>
@@ -346,13 +346,13 @@
             <batch:chunk reader="interactionReader"
                          processor="interactionMixProcessor"
                          writer="interactionMixImporter"
-                         commit-interval="50"
-                         retry-limit="10">
+                         commit-interval="50">
+<!--                         retry-limit="10">-->
 
-                <batch:retryable-exception-classes>
-                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>
-                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>
-                </batch:retryable-exception-classes>
+<!--                <batch:retryable-exception-classes>-->
+<!--                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>-->
+<!--                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>-->
+<!--                </batch:retryable-exception-classes>-->
 
                 <batch:streams>
                     <batch:stream ref="interactionReader"/>

--- a/intact-db-importer/src/main/resources/META-INF/intact-importer-spring.xml
+++ b/intact-db-importer/src/main/resources/META-INF/intact-importer-spring.xml
@@ -266,13 +266,13 @@
             <batch:chunk reader="interactionEvidenceReader"
                          processor="interactionEvidenceProcessor"
                          writer="interactionEvidenceImporter"
-                         commit-interval="50">
-<!--                         retry-limit="10">-->
+                         commit-interval="50"
+                         retry-limit="10">
 
-<!--                <batch:retryable-exception-classes>-->
-<!--                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>-->
-<!--                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>-->
-<!--                </batch:retryable-exception-classes>-->
+                <batch:retryable-exception-classes>
+                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>
+                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>
+                </batch:retryable-exception-classes>
 
                 <batch:streams>
                     <batch:stream ref="interactionEvidenceReader"/>
@@ -292,13 +292,13 @@
             <batch:chunk reader="modelledInteractionReader"
                          processor="modelledInteractionProcessor"
                          writer="modelledInteractionImporter"
-                         commit-interval="50">
-<!--                         retry-limit="10">-->
+                         commit-interval="50"
+                         retry-limit="10">
 
-<!--                <batch:retryable-exception-classes>-->
-<!--                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>-->
-<!--                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>-->
-<!--                </batch:retryable-exception-classes>-->
+                <batch:retryable-exception-classes>
+                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>
+                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>
+                </batch:retryable-exception-classes>
 
                 <batch:streams>
                     <batch:stream ref="modelledInteractionReader"/>
@@ -318,13 +318,13 @@
             <batch:chunk reader="complexReader"
                          processor="intactComplexEnricherCompositeProcessor"
                          writer="complexImporter"
-                         commit-interval="50">
-<!--                         retry-limit="10">-->
+                         commit-interval="50"
+                         retry-limit="10">
 
-<!--                <batch:retryable-exception-classes>-->
-<!--                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>-->
-<!--                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>-->
-<!--                </batch:retryable-exception-classes>-->
+                <batch:retryable-exception-classes>
+                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>
+                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>
+                </batch:retryable-exception-classes>
 
                 <batch:streams>
                     <batch:stream ref="complexReader"/>
@@ -346,13 +346,13 @@
             <batch:chunk reader="interactionReader"
                          processor="interactionMixProcessor"
                          writer="interactionMixImporter"
-                         commit-interval="50">
-<!--                         retry-limit="10">-->
+                         commit-interval="50"
+                         retry-limit="10">
 
-<!--                <batch:retryable-exception-classes>-->
-<!--                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>-->
-<!--                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>-->
-<!--                </batch:retryable-exception-classes>-->
+                <batch:retryable-exception-classes>
+                    <batch:include class="org.springframework.web.client.ResourceAccessException"/>
+                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>
+                </batch:retryable-exception-classes>
 
                 <batch:streams>
                     <batch:stream ref="interactionReader"/>

--- a/intact-enricher/pom.xml
+++ b/intact-enricher/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>intact-dataexchange-master</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/intact-enricher/src/main/java/uk/ac/ebi/intact/dataexchange/enricher/fetch/EnsemblGeneFetcher.java
+++ b/intact-enricher/src/main/java/uk/ac/ebi/intact/dataexchange/enricher/fetch/EnsemblGeneFetcher.java
@@ -1,12 +1,36 @@
 package uk.ac.ebi.intact.dataexchange.enricher.fetch;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import psidev.psi.mi.jami.bridges.exception.BridgeFailedException;
+import psidev.psi.mi.jami.model.Gene;
+import uk.ac.ebi.intact.dataexchange.enricher.EnricherContext;
+import uk.ac.ebi.intact.dataexchange.enricher.cache.EnricherCache;
+
+import java.util.Collection;
 
 @Component("intactEnsemblGeneFetcher")
 @Lazy
 public class EnsemblGeneFetcher extends psidev.psi.mi.jami.bridges.ensembl.EnsemblGeneFetcher {
+
+    @Autowired
+    private EnricherContext enricherContext;
+
     public EnsemblGeneFetcher() throws BridgeFailedException {
+    }
+
+    @Override
+    public Collection<Gene> fetchByIdentifier(String identifier) throws BridgeFailedException {
+        EnricherCache ensembleGeneCache = enricherContext.getCacheManager().getCache("EnsembleGene");
+
+        if (ensembleGeneCache.isKeyInCache(identifier)) {
+            return (Collection<Gene>) ensembleGeneCache.get(identifier);
+        }
+        else{
+            Collection<Gene> terms = super.fetchByIdentifier(identifier);
+            ensembleGeneCache.put(identifier, terms);
+            return terms;
+        }
     }
 }

--- a/intact-enricher/src/main/java/uk/ac/ebi/intact/dataexchange/enricher/fetch/EnsemblNucleicAcidFetcher.java
+++ b/intact-enricher/src/main/java/uk/ac/ebi/intact/dataexchange/enricher/fetch/EnsemblNucleicAcidFetcher.java
@@ -1,12 +1,36 @@
 package uk.ac.ebi.intact.dataexchange.enricher.fetch;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import psidev.psi.mi.jami.bridges.exception.BridgeFailedException;
+import psidev.psi.mi.jami.model.NucleicAcid;
+import uk.ac.ebi.intact.dataexchange.enricher.EnricherContext;
+import uk.ac.ebi.intact.dataexchange.enricher.cache.EnricherCache;
+
+import java.util.Collection;
 
 @Component("intactEnsemblNucleicAcidFetcher")
 @Lazy
 public class EnsemblNucleicAcidFetcher extends psidev.psi.mi.jami.bridges.ensembl.EnsemblNucleicAcidFetcher {
+
+    @Autowired
+    private EnricherContext enricherContext;
+
     public EnsemblNucleicAcidFetcher() throws BridgeFailedException {
+    }
+
+    @Override
+    public Collection<NucleicAcid> fetchByIdentifier(String identifier) throws BridgeFailedException {
+        EnricherCache ensembleNucleicAcidCache = enricherContext.getCacheManager().getCache("EnsemblNucleicAcid");
+
+        if (ensembleNucleicAcidCache.isKeyInCache(identifier)) {
+            return (Collection<NucleicAcid>) ensembleNucleicAcidCache.get(identifier);
+        }
+        else{
+            Collection<NucleicAcid> terms = super.fetchByIdentifier(identifier);
+            ensembleNucleicAcidCache.put(identifier, terms);
+            return terms;
+        }
     }
 }

--- a/intact-enricher/src/main/java/uk/ac/ebi/intact/dataexchange/enricher/fetch/NucleicAcidFetcher.java
+++ b/intact-enricher/src/main/java/uk/ac/ebi/intact/dataexchange/enricher/fetch/NucleicAcidFetcher.java
@@ -1,12 +1,36 @@
 package uk.ac.ebi.intact.dataexchange.enricher.fetch;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import psidev.psi.mi.jami.bridges.exception.BridgeFailedException;
+import psidev.psi.mi.jami.model.NucleicAcid;
+import uk.ac.ebi.intact.dataexchange.enricher.EnricherContext;
+import uk.ac.ebi.intact.dataexchange.enricher.cache.EnricherCache;
+
+import java.util.Collection;
 
 @Component("intactNucleicAcidFetcher")
 @Lazy
 public class NucleicAcidFetcher extends psidev.psi.mi.jami.bridges.rna.central.RNACentralFetcher {
+
+    @Autowired
+    private EnricherContext enricherContext;
+
     public NucleicAcidFetcher() throws BridgeFailedException {
+    }
+
+    @Override
+    public Collection<NucleicAcid> fetchByIdentifier(String identifier) throws BridgeFailedException {
+        EnricherCache nucleicAcidCache = enricherContext.getCacheManager().getCache("NucleicAcid");
+
+        if (nucleicAcidCache.isKeyInCache(identifier)) {
+            return (Collection<NucleicAcid>) nucleicAcidCache.get(identifier);
+        }
+        else{
+            Collection<NucleicAcid> terms = super.fetchByIdentifier(identifier);
+            nucleicAcidCache.put(identifier, terms);
+            return terms;
+        }
     }
 }

--- a/intact-enricher/src/main/java/uk/ac/ebi/intact/dataexchange/enricher/standard/CompositeInteractorEnricher.java
+++ b/intact-enricher/src/main/java/uk/ac/ebi/intact/dataexchange/enricher/standard/CompositeInteractorEnricher.java
@@ -74,7 +74,7 @@ public class CompositeInteractorEnricher extends psidev.psi.mi.jami.enricher.imp
     }
 
     public InteractorEnricher<NucleicAcid> getNucleicAcidEnricher() {
-        if (super.getGeneEnricher() == null){
+        if (super.getNucleicAcidEnricher() == null){
             super.setNucleicAcidEnricher((InteractorEnricher<NucleicAcid>)
                     ApplicationContextProvider.getBean("intactNucleicAcidEnricher"));
         }

--- a/intact-mi-cluster-score/pom.xml
+++ b/intact-mi-cluster-score/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>intact-dataexchange-master</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-mi-cluster-score</artifactId>

--- a/intact-mutation-export/pom.xml
+++ b/intact-mutation-export/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/intact-mutation-export/src/main/java/uk/ac/ebi/intact/export/mutation/listener/AbstractShortlabelGeneratorListener.java
+++ b/intact-mutation-export/src/main/java/uk/ac/ebi/intact/export/mutation/listener/AbstractShortlabelGeneratorListener.java
@@ -46,4 +46,9 @@ public class AbstractShortlabelGeneratorListener implements ShortlabelGeneratorL
     public void onObjectTypeError(TypeErrorEvent event) {
 
     }
+
+    @Override
+    public void onOtherErrorEvent(OtherErrorEvent event) {
+
+    }
 }

--- a/intact-pdbe-import/pom.xml
+++ b/intact-pdbe-import/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/intact-tasks/pom.xml
+++ b/intact-tasks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/intact-uniprot-export/pom.xml
+++ b/intact-uniprot-export/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>uk.ac.ebi.intact.dataexchange</groupId>
     <artifactId>intact-dataexchange-master</artifactId>
     <packaging>pom</packaging>
-    <version>3.3.1</version>
+    <version>3.3.2-SNAPSHOT</version>
 
     <name>IntAct Data Exchange</name>
     <description>Data Exchange Master POM</description>
@@ -22,10 +22,10 @@
         <core.version>2.8.1</core.version>
         <bridges.version>2.2.2</bridges.version>
         <commons.version>2.1.10</commons.version>
-        <intact.tools.version>1.2.5</intact.tools.version>
-        <intact.jami.version>2.2.6</intact.jami.version>
+        <intact.tools.version>1.2.6-SNAPSHOT</intact.tools.version>
+        <intact.jami.version>2.2.7-SNAPSHOT</intact.jami.version>
         <!--The version needs to be the same than in intact-jami to avoid problems-->
-        <psi.jami.version>3.5.0</psi.jami.version>
+        <psi.jami.version>3.5.1-SNAPSHOT</psi.jami.version>
         <spring.version>4.3.30.RELEASE</spring.version>
 
         <!--Properties for psixml-exchange: keep them in sync with jami-bridges until the module is updated-->

--- a/psimi/intact-psimi-exporter/pom.xml
+++ b/psimi/intact-psimi-exporter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
         <artifactId>intact-psimi-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-psimi-exporter</artifactId>

--- a/psimi/pom.xml
+++ b/psimi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/psimi/psimitab/intact-calimocho-converters/pom.xml
+++ b/psimi/psimitab/intact-calimocho-converters/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>psimitab-master</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-calimocho-converters</artifactId>

--- a/psimi/psimitab/intact-jami-mitab/pom.xml
+++ b/psimi/psimitab/intact-jami-mitab/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
         <artifactId>psimitab-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-jami-mitab</artifactId>

--- a/psimi/psimitab/intact-psimitab-converters/pom.xml
+++ b/psimi/psimitab/intact-psimitab-converters/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>psimitab-master</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/psimi/psimitab/intact-solr-home/pom.xml
+++ b/psimi/psimitab/intact-solr-home/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>psimitab-master</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/psimi/psimitab/intact-solr/pom.xml
+++ b/psimi/psimitab/intact-solr/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>psimitab-master</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/psimi/psimitab/pom.xml
+++ b/psimi/psimitab/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
         <artifactId>intact-psimi-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/psimi/psixml/intact-jami-xml/pom.xml
+++ b/psimi/psixml/intact-jami-xml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
         <artifactId>intact-psixml</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-jami-xml</artifactId>

--- a/psimi/psixml/intact-psixml-converters/pom.xml
+++ b/psimi/psixml/intact-psixml-converters/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>intact-psixml</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/psimi/psixml/intact-psixml-converters/src/main/java/uk/ac/ebi/intact/dataexchange/psimi/xml/converter/ConverterContext.java
+++ b/psimi/psixml/intact-psixml-converters/src/main/java/uk/ac/ebi/intact/dataexchange/psimi/xml/converter/ConverterContext.java
@@ -88,11 +88,11 @@ public class ConverterContext {
         // in order to avoid connection to the database, we list here all the MIs of DNA and RNA related terms
         rnaTypeMis = new HashSet( Arrays.asList( "MI:0320", "MI:0321", "MI:0322", "MI:0323", "MI:0324",
                 "MI:0325", "MI:0607", "MI:0608", "MI:0609", "MI:0610",
-                "MI:0611", "MI:0679", "MI:0679" ) );
+                "MI:0611", "MI:0679", "MI:0679", "MI:2204" ) );
 
         rnaTypeLabels = new HashSet( Arrays.asList( "ribonucleic acid", "catalytic rna", "guide rna", "heterogeneous nuclear rna", "messenger rna", "poly adenine", "transfer rna",
                 "small nuclear rna", "ribosomal rna", "small nucleolar rna", "small interfering rna", "signal recognition particle rna",
-                "poly adenine") );
+                "poly adenine", "micro rna") );
 
         dnaTypeMis = new HashSet( Arrays.asList( "MI:0319", "MI:0680", "MI:0681", "MI:0250" ) );
 

--- a/psimi/psixml/intact-psixml-dbimporter/pom.xml
+++ b/psimi/psixml/intact-psixml-dbimporter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>intact-psixml</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-psixml-dbimporter</artifactId>

--- a/psimi/psixml/intact-psixml-exchange/pom.xml
+++ b/psimi/psixml/intact-psixml-exchange/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
         <artifactId>intact-psixml</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/psimi/psixml/pom.xml
+++ b/psimi/psixml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
         <artifactId>intact-psimi-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/structured-abstract/pom.xml
+++ b/structured-abstract/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>structured-abstract</artifactId>


### PR DESCRIPTION
A few changes here:
- psi-jami version updated with fixes in https://github.com/MICommunity/psi-jami/pull/88
- Use of a cache for Ensemble and RNACentral fetchers, as we do for other fetchers
- Fix setter for nucleic acid enricher in `CompositeInteractorEnricher.java`