### PR TITLE
Refactor job to not deal with a big map

### DIFF
--- a/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/OrthologsFileParser.java
+++ b/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/OrthologsFileParser.java
@@ -3,7 +3,9 @@ package uk.ac.ebi.intact.ortholog;
 import lombok.extern.log4j.Log4j;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,5 +45,46 @@ public class OrthologsFileParser {
         log.info("File parsed.");
         log.info("Number of Panther identifiers: " + uniprotAndPTHR.size());
         return uniprotAndPTHR;
+    }
+
+    public static void parseFileAndSave(String inputFilePath, String outputFilePath) throws IOException {
+        Pattern uniprotKBRegex = Pattern.compile("UniProtKB=([A-Z0-9]+)");
+        Pattern pantherRegex = Pattern.compile("PTHR\\d+");
+        long uniprotAndPantherCount = 0;
+        log.info("Parsing file...");
+
+        // TODO: if the output file exists, delete it first so it's empty before we start writing on it
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(inputFilePath))) {
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                ArrayList<String> uniprotMatches = new ArrayList<>();
+
+                Matcher uniprotMatcher = uniprotKBRegex.matcher(line);
+                Matcher pantherMatcher = pantherRegex.matcher(line);
+
+                while (uniprotMatcher.find()) {
+                    uniprotMatches.add(uniprotMatcher.group(1));
+                }
+                while (pantherMatcher.find()) {
+                    for (String uniprotMatch : uniprotMatches) {
+                        writePair(outputFilePath, uniprotMatch, pantherMatcher.group());
+                        uniprotAndPantherCount += uniprotMatches.size();
+                    }
+                }
+            }
+        }
+
+        log.info("File parsed.");
+        log.info("Number of Panther identifiers: " + uniprotAndPantherCount);
+    }
+
+    private static void writePair(String filePath, String uniprotId, String pantherId) throws IOException {
+        try (FileWriter fileWriter = new FileWriter(filePath, true);
+             BufferedWriter bufferedWriter = new BufferedWriter(fileWriter)) {
+            bufferedWriter.write(uniprotId + "," + pantherId);
+            bufferedWriter.newLine(); // Optionally add a newline after the text
+            }
     }
 }

--- a/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/OrthologsProteinAssociation.java
+++ b/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/OrthologsProteinAssociation.java
@@ -152,4 +152,21 @@ public class OrthologsProteinAssociation {
             e.printStackTrace(); // Print the stack trace to help with debugging
         }
     }
+
+    public static String associateOneProteinToPantherId(String filePath, IntactProtein protein) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String[] parts = line.split(",");
+                if (parts.length == 2) {
+                    String proteinId = parts[0];
+                    if (proteinId.equals(protein.getUniprotkb())) {
+                        return parts[1];
+                    }
+
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/OrthologsProteinAssociation.java
+++ b/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/OrthologsProteinAssociation.java
@@ -153,7 +153,8 @@ public class OrthologsProteinAssociation {
         }
     }
 
-    public static String associateOneProteinToPantherId(String filePath, IntactProtein protein) throws IOException {
+    public static Collection<String> associateOneProteinToPantherIds(String filePath, IntactProtein protein) throws IOException {
+        List<String> pantherIds = new ArrayList<>();
         try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
             String line;
             while ((line = reader.readLine()) != null) {
@@ -161,12 +162,12 @@ public class OrthologsProteinAssociation {
                 if (parts.length == 2) {
                     String proteinId = parts[0];
                     if (proteinId.equals(protein.getUniprotkb())) {
-                        return parts[1];
+                        pantherIds.add(parts[1]);
                     }
 
                 }
             }
         }
-        return null;
+        return pantherIds;
     }
 }

--- a/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/OrthologsXrefWriter.java
+++ b/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/OrthologsXrefWriter.java
@@ -17,7 +17,14 @@ public class OrthologsXrefWriter {
     private final static String PANTHER_DATABASE_MI = "MI:0702";
     private final Map<String, IntactCvTerm> cvTermMap = new HashMap<>();
     private final IntactDao intactDao;
-    private final InteractorService interactorService;
+//    private final InteractorService interactorService;
+
+
+    public void addOrthologyXrefs(IntactProtein protein, Collection<String> pantherIds) throws Exception{
+        for (String pantherId: pantherIds) {
+            addOrthologyXref(protein, pantherId);
+        }
+    }
 
 
     public void addOrthologyXref(IntactProtein protein, String pantherId) throws Exception{

--- a/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/jobs/IntactProteinAndPantherProcessor.java
+++ b/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/jobs/IntactProteinAndPantherProcessor.java
@@ -6,34 +6,23 @@ import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemStream;
 import org.springframework.batch.item.ItemStreamException;
 import uk.ac.ebi.intact.jami.model.extension.IntactProtein;
-import uk.ac.ebi.intact.ortholog.OrthologsFileParser;
-import uk.ac.ebi.intact.ortholog.OrthologsProteinAssociation;
 import uk.ac.ebi.intact.ortholog.OrthologsXrefWriter;
-
-import java.io.IOException;
+import uk.ac.ebi.intact.ortholog.model.ProteinAndPantherGroup;
 
 @RequiredArgsConstructor
-public class IntactProteinAndPantherProcessor implements ItemProcessor<IntactProtein, IntactProtein>, ItemStream {
+public class IntactProteinAndPantherProcessor implements ItemProcessor<ProteinAndPantherGroup, IntactProtein>, ItemStream {
 
     private final OrthologsXrefWriter orthologsXrefWriter;
-    private final String uncompressedPantherFilePath;
-    private final String proteinPantherPairFilePath;
 
     @Override
-    public IntactProtein process(IntactProtein protein) throws Exception {
-        String pantherId = OrthologsProteinAssociation
-                .associateOneProteinToPantherId(proteinPantherPairFilePath, protein);
-        orthologsXrefWriter.addOrthologyXref(protein, pantherId);
-        return protein;
+    public IntactProtein process(ProteinAndPantherGroup proteinAndPantherGroup) throws Exception {
+        orthologsXrefWriter.addOrthologyXrefs(proteinAndPantherGroup.getProtein(), proteinAndPantherGroup.getPantherIds());
+        return proteinAndPantherGroup.getProtein();
     }
 
     @Override
     public void open(ExecutionContext executionContext) throws ItemStreamException {
-        try {
-            OrthologsFileParser.parseFileAndSave(uncompressedPantherFilePath, proteinPantherPairFilePath);
-        } catch (IOException e) {
-            throw new ItemStreamException("Error parsing the file: " + uncompressedPantherFilePath, e);
-        }
+
     }
 
     @Override

--- a/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/jobs/IntactProteinAndPantherProcessor.java
+++ b/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/jobs/IntactProteinAndPantherProcessor.java
@@ -8,26 +8,31 @@ import org.springframework.batch.item.ItemStreamException;
 import uk.ac.ebi.intact.jami.model.extension.IntactProtein;
 import uk.ac.ebi.intact.ortholog.OrthologsFileParser;
 import uk.ac.ebi.intact.ortholog.OrthologsProteinAssociation;
-import java.util.Map;
+import uk.ac.ebi.intact.ortholog.OrthologsXrefWriter;
+
+import java.io.IOException;
 
 @RequiredArgsConstructor
-public class IntactProteinAndPantherProcessor implements ItemProcessor<IntactProtein, Map<IntactProtein, String>>, ItemStream {
+public class IntactProteinAndPantherProcessor implements ItemProcessor<IntactProtein, IntactProtein>, ItemStream {
 
-    private final OrthologsProteinAssociation orthologsProteinAssociation;
-    private final String filePath;
-    private Map<String, String> uniprotAndPanther;
+    private final OrthologsXrefWriter orthologsXrefWriter;
+    private final String uncompressedPantherFilePath;
+    private final String proteinPantherPairFilePath;
 
     @Override
-    public Map<IntactProtein, String> process(IntactProtein protein) throws Exception {
-        return orthologsProteinAssociation.associateOneProteinToPantherID(uniprotAndPanther, protein);
+    public IntactProtein process(IntactProtein protein) throws Exception {
+        String pantherId = OrthologsProteinAssociation
+                .associateOneProteinToPantherId(proteinPantherPairFilePath, protein);
+        orthologsXrefWriter.addOrthologyXref(protein, pantherId);
+        return protein;
     }
 
     @Override
     public void open(ExecutionContext executionContext) throws ItemStreamException {
         try {
-            uniprotAndPanther = OrthologsFileParser.parseFile(filePath);
-        } catch (Exception e) {
-            throw new ItemStreamException("Error parsing the file: " + filePath, e);
+            OrthologsFileParser.parseFileAndSave(uncompressedPantherFilePath, proteinPantherPairFilePath);
+        } catch (IOException e) {
+            throw new ItemStreamException("Error parsing the file: " + uncompressedPantherFilePath, e);
         }
     }
 

--- a/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/jobs/IntactProteinAndPantherReader.java
+++ b/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/jobs/IntactProteinAndPantherReader.java
@@ -11,27 +11,42 @@ import org.springframework.batch.item.UnexpectedInputException;
 import uk.ac.ebi.intact.jami.model.extension.IntactProtein;
 import uk.ac.ebi.intact.ortholog.OrthologsFileParser;
 import uk.ac.ebi.intact.ortholog.OrthologsProteinAssociation;
+import uk.ac.ebi.intact.ortholog.model.ProteinAndPantherGroup;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Map;
 
 @RequiredArgsConstructor
-public class IntactProteinAndPantherReader implements ItemReader<IntactProtein>, ItemStream {
+public class IntactProteinAndPantherReader implements ItemReader<ProteinAndPantherGroup>, ItemStream {
 
     private final OrthologsProteinAssociation orthologsProteinAssociation;
-//    private final String filePath;
+    private final String uncompressedPantherFilePath;
+    private final String proteinPantherPairFilePath;
 
     private Iterator<IntactProtein> proteinIterator;
-//    private Iterator<Map.Entry<String, String>> uniprotAndPantherIterator;
 
     @Override
-    public IntactProtein read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
-        return proteinIterator.hasNext() ? proteinIterator.next() : null;
+    public ProteinAndPantherGroup read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
+        while (proteinIterator.hasNext()) {
+            IntactProtein protein = proteinIterator.next();
+            Collection<String> pantherIds = OrthologsProteinAssociation
+                    .associateOneProteinToPantherIds(proteinPantherPairFilePath, protein);
+            if (!pantherIds.isEmpty()) {
+                return new ProteinAndPantherGroup(protein, pantherIds);
+            }
+        }
+        return null;
     }
 
     @Override
     public void open(ExecutionContext executionContext) throws ItemStreamException {
+        try {
+            OrthologsFileParser.parseFileAndSave(uncompressedPantherFilePath, proteinPantherPairFilePath);
+        } catch (IOException e) {
+            throw new ItemStreamException("Error parsing the file: " + uncompressedPantherFilePath, e);
+        }
+
         Collection<IntactProtein> allProteins = orthologsProteinAssociation.getIntactProtein();
 //        Map<String, String> uniprotAndPanther = OrthologsFileParser.parseFile(filePath);
 //        uniprotAndPantherIterator = uniprotAndPanther.entrySet().iterator();

--- a/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/jobs/IntactProteinAndPantherReader.java
+++ b/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/jobs/IntactProteinAndPantherReader.java
@@ -20,10 +20,10 @@ import java.util.Map;
 public class IntactProteinAndPantherReader implements ItemReader<IntactProtein>, ItemStream {
 
     private final OrthologsProteinAssociation orthologsProteinAssociation;
-    private final String filePath;
+//    private final String filePath;
 
     private Iterator<IntactProtein> proteinIterator;
-    private Iterator<Map.Entry<String, String>> uniprotAndPantherIterator;
+//    private Iterator<Map.Entry<String, String>> uniprotAndPantherIterator;
 
     @Override
     public IntactProtein read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {

--- a/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/model/ProteinAndPantherGroup.java
+++ b/intact-orthology-import/src/main/java/uk/ac/ebi/intact/ortholog/model/ProteinAndPantherGroup.java
@@ -1,0 +1,13 @@
+package uk.ac.ebi.intact.ortholog.model;
+
+import lombok.Value;
+import uk.ac.ebi.intact.jami.model.extension.IntactProtein;
+
+import java.util.Collection;
+
+@Value
+public class ProteinAndPantherGroup {
+
+    IntactProtein protein;
+    Collection<String> pantherIds;
+}

--- a/intact-orthology-import/src/main/resources/META-INF/orthology-import-spring.xml
+++ b/intact-orthology-import/src/main/resources/META-INF/orthology-import-spring.xml
@@ -192,13 +192,12 @@
 
     <bean id="intactProteinAndPantherReader" class="uk.ac.ebi.intact.ortholog.jobs.IntactProteinAndPantherReader">
         <constructor-arg index="0" ref="orthologsProteinAssociation"/>
-<!--        <constructor-arg index="1" value="${filePath}"/>-->
+        <constructor-arg index="1" value="${uncompressedPantherFilePath}"/>
+        <constructor-arg index="2" value="${proteinPantherPairFilePath}"/>
     </bean>
 
     <bean id="intactProteinAndPantherProcessor" class="uk.ac.ebi.intact.ortholog.jobs.IntactProteinAndPantherProcessor">
         <constructor-arg index="0" value="orthologsXrefWriter"/>
-        <constructor-arg index="1" value="${uncompressedPantherFilePath}"/>
-        <constructor-arg index="2" value="${proteinPantherPairFilePath}"/>
     </bean>
 
     <bean id="intactProteinAndPantherWriter" class="uk.ac.ebi.intact.ortholog.jobs.IntactProteinAndPantherWriter">

--- a/intact-orthology-import/src/main/resources/META-INF/orthology-import-spring.xml
+++ b/intact-orthology-import/src/main/resources/META-INF/orthology-import-spring.xml
@@ -174,37 +174,38 @@
 
     <bean id="orthologsReaderTasklet" class="uk.ac.ebi.intact.ortholog.jobs.OrthologsReaderTasklet">
         <constructor-arg index="0" value="${urlPanther}"/>
-        <constructor-arg index="1" value="${filePath}"/>
+        <constructor-arg index="1" value="${uncompressedPantherFilePath}"/>
     </bean>
 
-    <bean id="orthologsItemReader" class="uk.ac.ebi.intact.ortholog.jobs.OrthologsItemReader">
-        <constructor-arg index="0" ref="orthologsProteinAssociation"/>
-        <constructor-arg index="1" value="${filePath}"/>
-    </bean>
+<!--    <bean id="orthologsItemReader" class="uk.ac.ebi.intact.ortholog.jobs.OrthologsItemReader">-->
+<!--        <constructor-arg index="0" ref="orthologsProteinAssociation"/>-->
+<!--        <constructor-arg index="1" value="${filePath}"/>-->
+<!--    </bean>-->
 
-    <bean id="orthologsItemProcessor" class="uk.ac.ebi.intact.ortholog.jobs.OrthologsItemProcessor">
-        <constructor-arg index="0" ref="orthologsXrefWriter"/>
-    </bean>
+<!--    <bean id="orthologsItemProcessor" class="uk.ac.ebi.intact.ortholog.jobs.OrthologsItemProcessor">-->
+<!--        <constructor-arg index="0" ref="orthologsXrefWriter"/>-->
+<!--    </bean>-->
 
-    <bean id="proteinCollectionWriter" class="uk.ac.ebi.intact.ortholog.jobs.ProteinCollectionWriter">
-        <constructor-arg index="0" ref="interactorService"/>
-    </bean>
+<!--    <bean id="proteinCollectionWriter" class="uk.ac.ebi.intact.ortholog.jobs.ProteinCollectionWriter">-->
+<!--        <constructor-arg index="0" ref="interactorService"/>-->
+<!--    </bean>-->
 
     <bean id="intactProteinAndPantherReader" class="uk.ac.ebi.intact.ortholog.jobs.IntactProteinAndPantherReader">
         <constructor-arg index="0" ref="orthologsProteinAssociation"/>
-        <constructor-arg index="1" value="${filePath}"/>
+<!--        <constructor-arg index="1" value="${filePath}"/>-->
     </bean>
 
     <bean id="intactProteinAndPantherProcessor" class="uk.ac.ebi.intact.ortholog.jobs.IntactProteinAndPantherProcessor">
-        <constructor-arg index="0" ref="orthologsProteinAssociation"/>
-        <constructor-arg index="1" value="${filePath}"/>
+        <constructor-arg index="0" value="orthologsXrefWriter"/>
+        <constructor-arg index="1" value="${uncompressedPantherFilePath}"/>
+        <constructor-arg index="2" value="${proteinPantherPairFilePath}"/>
     </bean>
 
     <bean id="intactProteinAndPantherWriter" class="uk.ac.ebi.intact.ortholog.jobs.IntactProteinAndPantherWriter">
         <constructor-arg index="0" ref="interactorService"/>
     </bean>
 
-<!--    Intact protein and panther association -->
+    <!--    Intact protein and panther association -->
     <batch:step id="proteinAndPantherAssociation" parent="basicBatchStep">
         <batch:tasklet transaction-manager="jamiTransactionManager">
             <batch:listeners>
@@ -231,30 +232,30 @@
     </batch:step>
 
     <!-- Import Steps -->
-    <batch:step id="orthologyImportStep" parent="basicBatchStep">
-        <batch:tasklet transaction-manager="jamiTransactionManager">
-            <batch:listeners>
-                <batch:listener ref="basicChunkLoggerListener"/>
-            </batch:listeners>
+    <!--    <batch:step id="orthologyImportStep" parent="basicBatchStep">-->
+    <!--        <batch:tasklet transaction-manager="jamiTransactionManager">-->
+    <!--            <batch:listeners>-->
+    <!--                <batch:listener ref="basicChunkLoggerListener"/>-->
+    <!--            </batch:listeners>-->
 
-            <batch:chunk reader="orthologsItemReader"
-                         processor="orthologsItemProcessor"
-                         writer="proteinCollectionWriter"
-                         retry-limit="10">
+    <!--            <batch:chunk reader="orthologsItemReader"-->
+    <!--                         processor="orthologsItemProcessor"-->
+    <!--                         writer="proteinCollectionWriter"-->
+    <!--                         retry-limit="10">-->
 
-                <batch:retryable-exception-classes>
-                    <batch:include class="org.springframework.batch.item.ItemStreamException"/>
-                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>
-                </batch:retryable-exception-classes>
+    <!--                <batch:retryable-exception-classes>-->
+    <!--                    <batch:include class="org.springframework.batch.item.ItemStreamException"/>-->
+    <!--                    <batch:include class="javax.net.ssl.SSLHandshakeException"/>-->
+    <!--                </batch:retryable-exception-classes>-->
 
-                <batch:streams>
-                    <batch:stream ref="orthologsItemReader"/>
-                    <batch:stream ref="orthologsItemProcessor"/>
-                    <batch:stream ref="proteinCollectionWriter"/>
-                </batch:streams>
-            </batch:chunk>
-        </batch:tasklet>
-    </batch:step>
+    <!--                <batch:streams>-->
+    <!--                    <batch:stream ref="orthologsItemReader"/>-->
+    <!--                    <batch:stream ref="orthologsItemProcessor"/>-->
+    <!--                    <batch:stream ref="proteinCollectionWriter"/>-->
+    <!--                </batch:streams>-->
+    <!--            </batch:chunk>-->
+    <!--        </batch:tasklet>-->
+    <!--    </batch:step>-->
 
     <!--Import jobs -->
     <batch:job id="orthologyImport" job-repository="basicBatchJobRepository" parent="basicBatchJob">
@@ -269,8 +270,7 @@
             <batch:next on="*" to="associationStep"/>
         </batch:step>
 
-        <batch:step id="associationStep" parent="proteinAndPantherAssociation" next="importStep"/>
-        <batch:step id="importStep" parent="orthologyImportStep"/>
+        <batch:step id="associationStep" parent="proteinAndPantherAssociation"/>
 
     </batch:job>
 </beans>

--- a/intact-orthology-import/src/main/resources/META-INF/orthology-import.properties
+++ b/intact-orthology-import/src/main/resources/META-INF/orthology-import.properties
@@ -1,7 +1,9 @@
 jami.user.context.id=ORTHOLOG_IMPORTER
 
 reportFile=orthologsReport.txt
-filePath=orthologsData.txt
+#filePath=orthologsData.txt
+uncompressedPantherFilePath=orthologsData.txt
+proteinPantherPairFilePath=ProteinAndOrthologPairs.txt
 urlPanther=http://data.pantherdb.org/ftp/ortholog/current_release/AllOrthologs.tar.gz
 
 ac.prefix=EBI


### PR DESCRIPTION
A refactor to not have the big map in memory, and process just a protein at a time.
It would be slower, but it should not have any memory issues.