### PR TITLE
Store interactor xrefs in solr

### DIFF
--- a/complex-go-export/pom.xml
+++ b/complex-go-export/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>complex-go-export</artifactId>

--- a/complex-pdb-export/pom.xml
+++ b/complex-pdb-export/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>complex-pdb-export</artifactId>

--- a/complex-tab-export/pom.xml
+++ b/complex-tab-export/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
 

--- a/complex-uniprot-dr-export/pom.xml
+++ b/complex-uniprot-dr-export/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>complex-uniprot-dr-export</artifactId>

--- a/cttv-exporter/pom.xml
+++ b/cttv-exporter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/imex-id-update/pom.xml
+++ b/imex-id-update/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.ac.ebi.intact.dataexchange.imex</groupId>

--- a/intact-cvutils/pom.xml
+++ b/intact-cvutils/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/intact-db-importer/pom.xml
+++ b/intact-db-importer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-db-importer</artifactId>

--- a/intact-enricher/pom.xml
+++ b/intact-enricher/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>intact-dataexchange-master</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/intact-mi-cluster-score/pom.xml
+++ b/intact-mi-cluster-score/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>intact-dataexchange-master</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-mi-cluster-score</artifactId>

--- a/intact-mutation-export/pom.xml
+++ b/intact-mutation-export/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/intact-orthology-import/pom.xml
+++ b/intact-orthology-import/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-orthology-import</artifactId>

--- a/intact-pdbe-import/pom.xml
+++ b/intact-pdbe-import/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/intact-tasks/pom.xml
+++ b/intact-tasks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/intact-uniprot-export/pom.xml
+++ b/intact-uniprot-export/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>uk.ac.ebi.intact.dataexchange</groupId>
     <artifactId>intact-dataexchange-master</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
 
     <name>IntAct Data Exchange</name>
     <description>Data Exchange Master POM</description>

--- a/psimi/intact-psimi-exporter/pom.xml
+++ b/psimi/intact-psimi-exporter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
         <artifactId>intact-psimi-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-psimi-exporter</artifactId>

--- a/psimi/pom.xml
+++ b/psimi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/psimi/psimitab/intact-calimocho-converters/pom.xml
+++ b/psimi/psimitab/intact-calimocho-converters/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>psimitab-master</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-calimocho-converters</artifactId>

--- a/psimi/psimitab/intact-jami-mitab/pom.xml
+++ b/psimi/psimitab/intact-jami-mitab/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
         <artifactId>psimitab-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-jami-mitab</artifactId>

--- a/psimi/psimitab/intact-psimitab-converters/pom.xml
+++ b/psimi/psimitab/intact-psimitab-converters/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>psimitab-master</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/psimi/psimitab/intact-solr-home/pom.xml
+++ b/psimi/psimitab/intact-solr-home/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>psimitab-master</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/psimi/psimitab/intact-solr/pom.xml
+++ b/psimi/psimitab/intact-solr/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>psimitab-master</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/psimi/psimitab/intact-solr/src/main/java/uk/ac/ebi/intact/dataexchange/psimi/solr/complex/ComplexInteractor.java
+++ b/psimi/psimitab/intact-solr/src/main/java/uk/ac/ebi/intact/dataexchange/psimi/solr/complex/ComplexInteractor.java
@@ -1,5 +1,7 @@
 package uk.ac.ebi.intact.dataexchange.psimi.solr.complex;
 
+import java.util.List;
+
 public class ComplexInteractor {
 
     /*************************/
@@ -15,7 +17,8 @@ public class ComplexInteractor {
                              String description,
                              String stochiometry,
                              String interactorType,
-                             String organismName) {
+                             String organismName,
+                             List<ComplexInteractorXref> xrefs) {
         this.identifier = identifier;
         this.identifierLink = identifierLink;
         this.name = name;
@@ -23,6 +26,7 @@ public class ComplexInteractor {
         this.stochiometry = stochiometry;
         this.interactorType = interactorType;
         this.organismName = organismName;
+        this.xrefs = xrefs;
     }
 
     /*********************************/
@@ -85,6 +89,14 @@ public class ComplexInteractor {
         this.organismName = organismName;
     }
 
+    public List<ComplexInteractorXref> getXrefs() {
+        return xrefs;
+    }
+
+    public void setXrefs(List<ComplexInteractorXref> xrefs) {
+        this.xrefs = xrefs;
+    }
+
     /********************************/
     /*      Private attributes      */
     /********************************/
@@ -96,4 +108,5 @@ public class ComplexInteractor {
     private String stochiometry = null;
     private String interactorType;
     private String organismName;
+    private List<ComplexInteractorXref> xrefs;
 }

--- a/psimi/psimitab/intact-solr/src/main/java/uk/ac/ebi/intact/dataexchange/psimi/solr/complex/ComplexInteractorXref.java
+++ b/psimi/psimitab/intact-solr/src/main/java/uk/ac/ebi/intact/dataexchange/psimi/solr/complex/ComplexInteractorXref.java
@@ -1,0 +1,66 @@
+package uk.ac.ebi.intact.dataexchange.psimi.solr.complex;
+
+public class ComplexInteractorXref {
+
+    /*************************/
+    /*      Constructors     */
+    /*************************/
+
+    public ComplexInteractorXref() {
+    }
+
+    public ComplexInteractorXref(String identifier,
+                                 String identifierLink,
+                                 String database,
+                                 String qualifier) {
+        this.identifier = identifier;
+        this.identifierLink = identifierLink;
+        this.database = database;
+        this.qualifier = qualifier;
+    }
+
+    /*********************************/
+    /*      Getters and Setters      */
+    /*********************************/
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public String getIdentifierLink() {
+        return identifierLink;
+    }
+
+    public void setIdentifierLink(String identifierLink) {
+        this.identifierLink = identifierLink;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(String database) {
+        this.database = database;
+    }
+
+    public String getQualifier() {
+        return qualifier;
+    }
+
+    public void setQualifier(String qualifier) {
+        this.qualifier = qualifier;
+    }
+
+    /********************************/
+    /*      Private attributes      */
+    /********************************/
+
+    private String identifier = null;
+    private String identifierLink = null;
+    private String database = null;
+    private String qualifier = null;
+}

--- a/psimi/psimitab/intact-solr/src/main/java/uk/ac/ebi/intact/dataexchange/psimi/solr/enricher/ComplexSolrEnricher.java
+++ b/psimi/psimitab/intact-solr/src/main/java/uk/ac/ebi/intact/dataexchange/psimi/solr/enricher/ComplexSolrEnricher.java
@@ -40,8 +40,12 @@ public class ComplexSolrEnricher extends AbstractOntologyEnricher{
     private PsimiTabReader reader;
     private final ObjectMapper mapper;
 
-    private final static String EXP_EVIDENCE="exp-evidence";
-    private final static String INTACT_SECONDARY="intact-secondary";
+    private static final String EXP_EVIDENCE="exp-evidence";
+    private static final String INTACT_SECONDARY="intact-secondary";
+
+    // Currently, we are only storing interactors xrefs from the following databases:
+    // - panther (MI:0702)
+    private static final Set<String> INTERACTOR_XREF_DATABASE_MIS_TO_STORE = Set.of("MI:0702");
 
     /*************************/
     /*      Constructor      */
@@ -204,8 +208,9 @@ public class ComplexSolrEnricher extends AbstractOntologyEnricher{
         Interactor interactor = participant.getInteractor();
         String identifier = ComplexUtils.getParticipantIdentifier(participant);
 
-        // TODO: filter, maybe by database, to not store all xrefs, only those we want (like panther)
         List<ComplexInteractorXref> xrefs = interactor.getXrefs().stream()
+                .filter(xref -> xref.getCvDatabase() != null)
+                .filter(xref -> INTERACTOR_XREF_DATABASE_MIS_TO_STORE.contains(xref.getCvDatabase().getIdentifier()))
                 .map(xref -> new ComplexInteractorXref(
                         xref.getPrimaryId(),
                         ComplexUtils.getIdentifierLink(xref, xref.getPrimaryId()),

--- a/psimi/psimitab/intact-solr/src/main/java/uk/ac/ebi/intact/dataexchange/psimi/solr/enricher/ComplexSolrEnricher.java
+++ b/psimi/psimitab/intact-solr/src/main/java/uk/ac/ebi/intact/dataexchange/psimi/solr/enricher/ComplexSolrEnricher.java
@@ -204,6 +204,7 @@ public class ComplexSolrEnricher extends AbstractOntologyEnricher{
         Interactor interactor = participant.getInteractor();
         String identifier = ComplexUtils.getParticipantIdentifier(participant);
 
+        // TODO: filter, maybe by database, to not store all xrefs, only those we want (like panther)
         List<ComplexInteractorXref> xrefs = interactor.getXrefs().stream()
                 .map(xref -> new ComplexInteractorXref(
                         xref.getPrimaryId(),

--- a/psimi/psimitab/intact-solr/src/main/java/uk/ac/ebi/intact/dataexchange/psimi/solr/util/ComplexUtils.java
+++ b/psimi/psimitab/intact-solr/src/main/java/uk/ac/ebi/intact/dataexchange/psimi/solr/util/ComplexUtils.java
@@ -59,6 +59,10 @@ public final class ComplexUtils {
 
     public static String getParticipantIdentifierLink(Component participant, String identifier) {
         InteractorXref xref = getParticipantIdentifierXref(participant);
+        return getIdentifierLink(xref, identifier);
+    }
+
+    public static String getIdentifierLink(InteractorXref xref, String identifier) {
         if (xref != null && xref.getParent() != null) {
             Annotation annot = AnnotatedObjectUtils.findAnnotationByTopicMiOrLabel(xref.getCvDatabase(), SEARCH_MI);
             if (annot == null) {

--- a/psimi/psimitab/pom.xml
+++ b/psimi/psimitab/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
         <artifactId>intact-psimi-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/psimi/psixml/intact-jami-xml/pom.xml
+++ b/psimi/psixml/intact-jami-xml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
         <artifactId>intact-psixml</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-jami-xml</artifactId>

--- a/psimi/psixml/intact-psixml-converters/pom.xml
+++ b/psimi/psixml/intact-psixml-converters/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>intact-psixml</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/psimi/psixml/intact-psixml-dbimporter/pom.xml
+++ b/psimi/psixml/intact-psixml-dbimporter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>intact-psixml</artifactId>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-psixml-dbimporter</artifactId>

--- a/psimi/psixml/intact-psixml-exchange/pom.xml
+++ b/psimi/psixml/intact-psixml-exchange/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
         <artifactId>intact-psixml</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/psimi/psixml/pom.xml
+++ b/psimi/psixml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange.psimi</groupId>
         <artifactId>intact-psimi-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/structured-abstract/pom.xml
+++ b/structured-abstract/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.dataexchange</groupId>
         <artifactId>intact-dataexchange-master</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>structured-abstract</artifactId>


### PR DESCRIPTION
Store component xrefs, only for the databases specific, in SOLR. This is so it can be used by complex portal search results.

So far the only DB we store xrefs of is panther, but we could add more in the future easily.